### PR TITLE
Exception class wasn't included properly

### DIFF
--- a/src/PhpWhois/Tests/DomainTest.php
+++ b/src/PhpWhois/Tests/DomainTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace PhpWhois\Tests;
+
+class DomainTest extends TestCase
+{
+    /**
+     * @test
+     * @expectedException        Exception
+     * @expectedExceptionMessage Domain seems to be invalid.
+     */
+    public function it_should_throw_exception_when_wrong_domain_is_given()
+    {
+        $whois = new \PhpWhois\Whois('camping.ziemys.net');
+        $whois->lookup();
+    }
+}

--- a/src/PhpWhois/Whois.php
+++ b/src/PhpWhois/Whois.php
@@ -11,6 +11,8 @@
 
 namespace PhpWhois;
 
+use Exception;
+
 /**
  * Whois
  * @author Peter Kokot <peterkokot@gmail.com>


### PR DESCRIPTION
Exception should be included through `use` ir `\` statement. Added test cases.
